### PR TITLE
Bolt Connection support for specifying a Neo4j 4 database

### DIFF
--- a/src/protocol/bolt/src/main/java/org/apache/jmeter/protocol/bolt/config/BoltConnectionElement.java
+++ b/src/protocol/bolt/src/main/java/org/apache/jmeter/protocol/bolt/config/BoltConnectionElement.java
@@ -44,6 +44,7 @@ public class BoltConnectionElement extends AbstractTestElement
 
     public static final String BOLT_CONNECTION = "boltConnection";
     public static final String DATABASE = "database";
+    public static final String DEFAULT_DATABASE = "neo4j";
 
     public BoltConnectionElement() {
     }
@@ -69,7 +70,7 @@ public class BoltConnectionElement extends AbstractTestElement
             synchronized (this) {
                 driver = GraphDatabase.driver(getBoltUri(), AuthTokens.basic(getUsername(), getPassword()));
                 variables.putObject(BOLT_CONNECTION, driver);
-                variables.put(DATABASE, database==null || database.length()==0 ? "neo4j":database);
+                variables.put(DATABASE, database==null || database.length()==0 ? DEFAULT_DATABASE :database);
             }
         }
     }

--- a/src/protocol/bolt/src/main/java/org/apache/jmeter/protocol/bolt/config/BoltConnectionElement.java
+++ b/src/protocol/bolt/src/main/java/org/apache/jmeter/protocol/bolt/config/BoltConnectionElement.java
@@ -39,9 +39,11 @@ public class BoltConnectionElement extends AbstractTestElement
     private String boltUri;
     private String username;
     private String password;
+    private String database;
     private Driver driver;
 
     public static final String BOLT_CONNECTION = "boltConnection";
+    public static final String DATABASE = "database";
 
     public BoltConnectionElement() {
     }
@@ -67,6 +69,7 @@ public class BoltConnectionElement extends AbstractTestElement
             synchronized (this) {
                 driver = GraphDatabase.driver(getBoltUri(), AuthTokens.basic(getUsername(), getPassword()));
                 variables.putObject(BOLT_CONNECTION, driver);
+                variables.put(DATABASE, database==null || database.length()==0 ? "neo4j":database);
             }
         }
     }
@@ -116,7 +119,19 @@ public class BoltConnectionElement extends AbstractTestElement
         this.password = password;
     }
 
+    public String getDatabase() {
+        return database;
+    }
+
+    public void setDatabase(String database) {
+        this.database = database;
+    }
+
     public static Driver getDriver() {
         return (Driver) JMeterContextService.getContext().getVariables().getObject(BOLT_CONNECTION);
+    }
+
+    public static String getDatabaseName() {
+        return JMeterContextService.getContext().getVariables().get(DATABASE);
     }
 }

--- a/src/protocol/bolt/src/main/java/org/apache/jmeter/protocol/bolt/config/BoltConnectionElementBeanInfo.java
+++ b/src/protocol/bolt/src/main/java/org/apache/jmeter/protocol/bolt/config/BoltConnectionElementBeanInfo.java
@@ -33,7 +33,7 @@ public class BoltConnectionElementBeanInfo extends BeanInfoSupport {
     public BoltConnectionElementBeanInfo() {
         super(BoltConnectionElement.class);
 
-        createPropertyGroup("connection", new String[] { "boltUri", "username", "password" });
+        createPropertyGroup("connection", new String[] { "boltUri", "username", "password", "database" });
 
         PropertyDescriptor propertyDescriptor =  property("boltUri");
         propertyDescriptor.setValue(NOT_UNDEFINED, Boolean.TRUE);
@@ -44,6 +44,9 @@ public class BoltConnectionElementBeanInfo extends BeanInfoSupport {
         propertyDescriptor = property("password", TypeEditor.PasswordEditor);
         propertyDescriptor.setValue(NOT_UNDEFINED, Boolean.TRUE);
         propertyDescriptor.setValue(DEFAULT, "");
+        propertyDescriptor = property("database");
+        propertyDescriptor.setValue(NOT_UNDEFINED, Boolean.TRUE);
+        propertyDescriptor.setValue(DEFAULT, "neo4j");
 
         if(log.isDebugEnabled()) {
             String descriptorsAsString = Arrays.stream(getPropertyDescriptors())

--- a/src/protocol/bolt/src/main/java/org/apache/jmeter/protocol/bolt/sampler/BoltSampler.java
+++ b/src/protocol/bolt/src/main/java/org/apache/jmeter/protocol/bolt/sampler/BoltSampler.java
@@ -39,6 +39,7 @@ import org.neo4j.driver.Driver;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Result;
 import org.neo4j.driver.Session;
+import org.neo4j.driver.SessionConfig;
 import org.neo4j.driver.exceptions.Neo4jException;
 import org.neo4j.driver.summary.ResultSummary;
 
@@ -82,7 +83,8 @@ public class BoltSampler extends AbstractBoltTestElement implements Sampler, Tes
 
         try {
             res.setResponseHeaders("Cypher request: " + getCypher());
-            res.setResponseData(execute(BoltConnectionElement.getDriver(), getCypher(), params), StandardCharsets.UTF_8.name());
+            res.setResponseData(execute(BoltConnectionElement.getDriver(), BoltConnectionElement.getDatabaseName(),
+                    getCypher(), params), StandardCharsets.UTF_8.name());
         } catch (Exception ex) {
             res = handleException(res, ex);
         } finally {
@@ -100,8 +102,8 @@ public class BoltSampler extends AbstractBoltTestElement implements Sampler, Tes
         return APPLICABLE_CONFIG_CLASSES.contains(guiClass);
     }
 
-    private String execute(Driver driver, String cypher, Map<String, Object> params) {
-        try (Session session = driver.session()) {
+    private String execute(Driver driver, String database, String cypher, Map<String, Object> params) {
+        try (Session session = driver.session(SessionConfig.forDatabase(database))) {
             Result statementResult = session.run(cypher, params);
             return response(statementResult);
         }

--- a/src/protocol/bolt/src/main/resources/org/apache/jmeter/protocol/bolt/config/BoltConnectionElementResources.properties
+++ b/src/protocol/bolt/src/main/resources/org/apache/jmeter/protocol/bolt/config/BoltConnectionElementResources.properties
@@ -23,3 +23,5 @@ username.displayName=Username
 username.shortDescription=Username
 password.displayName=Password
 password.shortDescription=Password
+database.displayName=Database
+database.shortDescription=Database

--- a/src/protocol/bolt/src/test/groovy/org/apache/jmeter/protocol/bolt/sampler/BoltSamplerSpec.groovy
+++ b/src/protocol/bolt/src/test/groovy/org/apache/jmeter/protocol/bolt/sampler/BoltSamplerSpec.groovy
@@ -24,6 +24,7 @@ import org.apache.jmeter.threads.JMeterVariables
 import org.neo4j.driver.Driver
 import org.neo4j.driver.Result
 import org.neo4j.driver.Session
+import org.neo4j.driver.SessionConfig
 import org.neo4j.driver.exceptions.ClientException
 import org.neo4j.driver.summary.ResultSummary
 import org.neo4j.driver.summary.SummaryCounters
@@ -35,6 +36,7 @@ class BoltSamplerSpec extends Specification {
     BoltSampler sampler
     Entry entry
     Session session
+    String database = "neo4j"
 
     def setup() {
         sampler = new BoltSampler()
@@ -44,10 +46,11 @@ class BoltSamplerSpec extends Specification {
         def variables = new JMeterVariables()
         // ugly but could not find a better way to pass the driver to the sampler...
         variables.putObject(BoltConnectionElement.BOLT_CONNECTION, driver)
+        variables.putObject(BoltConnectionElement.DATABASE, database)
         JMeterContextService.getContext().setVariables(variables)
         entry.addConfigElement(boltConfig)
         session = Mock(Session)
-        driver.session() >> session
+        driver.session(SessionConfig.forDatabase(database)) >> session
     }
 
     def "should execute return success on successful query"() {

--- a/src/protocol/bolt/src/test/groovy/org/apache/jmeter/protocol/bolt/sampler/BoltSamplerSpec.groovy
+++ b/src/protocol/bolt/src/test/groovy/org/apache/jmeter/protocol/bolt/sampler/BoltSamplerSpec.groovy
@@ -36,7 +36,6 @@ class BoltSamplerSpec extends Specification {
     BoltSampler sampler
     Entry entry
     Session session
-    String database = "neo4j"
 
     def setup() {
         sampler = new BoltSampler()
@@ -46,11 +45,11 @@ class BoltSamplerSpec extends Specification {
         def variables = new JMeterVariables()
         // ugly but could not find a better way to pass the driver to the sampler...
         variables.putObject(BoltConnectionElement.BOLT_CONNECTION, driver)
-        variables.putObject(BoltConnectionElement.DATABASE, database)
+        variables.putObject(BoltConnectionElement.DATABASE, BoltConnectionElement.DATABASE)
         JMeterContextService.getContext().setVariables(variables)
         entry.addConfigElement(boltConfig)
         session = Mock(Session)
-        driver.session(SessionConfig.forDatabase(database)) >> session
+        driver.session(SessionConfig.forDatabase(BoltConnectionElement.DATABASE)) >> session
     }
 
     def "should execute return success on successful query"() {


### PR DESCRIPTION
## Description
The Neo4j Bolt driver was upgraded to 4.0.1, adding support now to allow the specification of which Neo4j database to run against.

## Motivation and Context
 Multi database support was added in Neo4j 4.0. With this change, the Bolt Connection allows users to specify which database to run their tests against, offering much better flexibility as opposed to forcing tests to run against the default database.

## How Has This Been Tested?
.`/gradlew check` was successful

Fixed BoltSamplerSpec.groovy 

## Screenshots (if appropriate):

## Types of changes
- New feature (non-breaking change which adds functionality)


## Checklist:

- [ x] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
